### PR TITLE
fix: improve sitemap template to include actual update date

### DIFF
--- a/overrides/sitemap.xml
+++ b/overrides/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link and (file.page.abs_url or file.page.canonical_url) %}
+    <url>
+        <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
+        {#- NOTE: we exclude `lastmod` for pages using a template, as their update time is not correctly detected #}
+        {%- if not file.page.meta.template and file.page.meta.git_revision_date_localized_raw_iso_datetime %}
+        <lastmod>{{ (file.page.meta.git_revision_date_localized_raw_iso_datetime + "+00:00") | replace(" ", "T") }}</lastmod>
+        {%- endif %}
+        {#- NOTE: Add a lastmod to pages that have date in their meta data, e.g., blog posts. #}
+        {%- if file.page.meta.template and file.page.meta.date %}
+        <lastmod>{{ (file.page.meta.date.updated or file.page.meta.date.created) | replace(" ", "T") }}</lastmod>
+        {%- endif %}
+        {#- NOTE: You can add a priority to the front matter (meta) for a page. #}
+        {#- Valid values range from 0.0 to 1.0, if no value is set the default is 0.5. #}
+        {#- reference: https://www.sitemaps.org/protocol.html #}
+        {%- if file.page.meta.priority %}
+        <priority>{{ file.page.meta.priority }}</priority>
+        {%- endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>


### PR DESCRIPTION
Based off the template: https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/howto/override-a-theme/#example-populate-sitemapxml

Added `lastmod` for blog posts based on the metadata `date: updated` or `date: created` as a fallback.

Closes #179 