### PR TITLE
ci: replace docker-run action with usage of docker CLI directly

### DIFF
--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -1,0 +1,43 @@
+name: Check Redirects
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check_redirects:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Run the production stack
+        run: |
+          # speed up build by setting CI=false
+          docker compose build --build-arg STATS_WEBSITE_ID=test_website_id --build-arg CI=false
+          docker compose up -d
+      - name: Check stats website ID
+        run: |
+          curl --silent http://localhost | grep --quiet 'data-website-id="test_website_id"'
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        id: setup-uv
+        with:
+          # renovate: datasource=pypi dependency=uv
+          version: "0.10.2"
+      - name: Check redirects
+        run: |
+          uv run --script .github/redirects/check_redirects.py
+      - name: Stop production stack
+        run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,18 +50,6 @@ jobs:
           --user root \
           davidanson/markdownlint-cli2-rules:${{ env.MARKDOWNLINT_CLI2_VERSION }} \
           markdownlint-cli2 --config .github/markdownlint/.markdownlint-cli2.yaml "**/*.md"
-      - name: Run the production stack
-        run: |
-          # speed up build by setting CI=false
-          docker compose build --build-arg STATS_WEBSITE_ID=test_website_id --build-arg CI=false
-          docker compose up -d
-      - name: Check stats website ID
-        run: |
-          curl --silent http://localhost | grep --quiet 'data-website-id="test_website_id"'
-      - name: Check redirects
-        run: uv run --script .github/redirects/check_redirects.py
-      - name: Stop production stack
-        run: docker compose down
 
   build:
     # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories


### PR DESCRIPTION
Fixes:

```console
docker: Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```

See for example: https://github.com/mschoettle/website/actions/runs/22128756271/job/63964252972